### PR TITLE
Add a cache aware version of the client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Putting a document:
 
 ```clojure
 
-(put-document northwind "Employees/10" { :FirstName "David" :LastName "Smith" :age 50 })
+(put-document! northwind "Employees/10" { :FirstName "David" :LastName "Smith" :age 50 })
 
 ```
 
@@ -260,7 +260,7 @@ The client will be represented by a map that looks like:
 
 ```
 
-When this client is used to (put-document), (put-index) or for (bulk-operations) if the master is down then one of the replications will be used for write operations.
+When this client is used to (put-document!), (put-index!) or for (bulk-operations!) if the master is down then one of the replications will be used for write operations.
 
 ## Build & Test
 

--- a/README.md
+++ b/README.md
@@ -212,9 +212,21 @@ Watching for index changes:
 
 There are a number of "configuration" options that can be used when creating a client: 
 
+### Caching
+
+To create a client that supports caching:
+
+```clojure
+
+(def northwind (client "http://localhost:8080" "northwind" {:caching? true}))
+
+```
+
+When this option is used documents loading using ```load-documents``` will be cached. put-document! and bulk-operations! will update this local cache as well as the server.
+
 ###  Replication
 
-To create an client that supports replication:
+To create a client that supports replication:
 
 ```clojure
 

--- a/src/clj_ravendb/caching.clj
+++ b/src/clj_ravendb/caching.clj
@@ -65,7 +65,9 @@
         doc (second args)
         id (first args)]
     (if (= 200 status)
-      (swap! client-cache conj (merge {:key id :cached? true} doc)))
+      (do
+        (reset! client-cache (remove (fn [{:keys [key]}] (some #{key} id)) @client-cache))
+        (swap! client-cache conj (merge {:key id :cached? true} doc))))
     response))
 
 (defn caching-client

--- a/src/clj_ravendb/caching.clj
+++ b/src/clj_ravendb/caching.clj
@@ -1,0 +1,97 @@
+(ns clj-ravendb.caching
+  (:require [clojure.set :refer [difference]]
+            [clj-ravendb.rest :as rest]
+            [clj-ravendb.util :refer :all]))
+
+(def client-cache (atom []))
+
+(defn load-documents
+  "Loads a collection of documents represented
+  by the given document ids.
+
+  Wraps a clj-ravendb.rest client for the purposes
+  of local caching.
+
+  Optionally takes a map of options.
+  :request-builder is a custom request builder fn.
+  :response-parser is a customer response parser fn."
+  [{:keys [load-documents rest-client] :as client} & args]
+  (let [rest-load-documents (:load-documents rest-client)
+        doc-ids (first args)
+        cached-ids (map :key @client-cache)
+        not-cached (difference (set doc-ids) (set cached-ids))]
+    (when-let [response (apply rest-load-documents client (assoc (vec args) 1 not-cached))]
+      (when-let [results (:results response)]
+        (swap! client-cache concat (map (fn [r]
+                                          (assoc r :cached? true)) results)))
+      {:status (:status response)
+       :results (filter (fn [{:keys [key]}] (some #{key} doc-ids)) @client-cache)})))
+
+(defn bulk-operations!
+  "Handles a given set of bulk operations that
+  correspond to RavenDB batch req.
+
+  Wraps a clj-ravendb.rest client for the purposes
+  of local caching.
+
+  Optionally takes a map of options.
+  :request-builder is a custom request builder fn.
+  :response-parser is a customer response parser fn."
+  [{:keys [bulk-operations! rest-client] :as client} & args]
+  (let [rest-bulk-operations! (:bulk-operations! rest-client)
+        operations (first args)
+        dels (map :Key (filter #(= (:Method %) "DELETE") operations))
+        puts (filter #(= (:Method %) "PUT") operations)
+        {:keys [status] :as response} (apply rest-bulk-operations! client args)]
+    (if (= 200 status)
+      (do
+        (reset! client-cache (remove (fn [{:keys [key]}] (some #{key} dels)) @client-cache))
+        (swap! client-cache concat (map (fn [{:keys [Key Document]}] {:key Key :document Document}) puts))))
+    response))
+
+(defn put-document!
+  "Creates or updates a document by its key. Where 'document'
+  is a map.
+
+  Wraps a clj-ravendb.rest client for the purposes
+  of local caching.
+
+  Optionally takes a map of options.
+  :request-builder is a custom request builder fn.
+  :response-parser is a customer response parser fn."
+  [{:keys [put-document! rest-client] :as client} & args]
+  (let [rest-put-document! (:put-document! rest-client)
+        {:keys [status] :as response} (apply rest-put-document! client args)
+        doc (second args)
+        id (first args)]
+    (if (= 200 status)
+      (swap! client-cache conj (merge {:key id :cached? true} doc)))
+    response))
+
+(defn caching-client
+  "Gets a client for a RavenDB endpoint at the
+  given url and database.
+
+  Wraps a clj-ravendb.rest client for the purposes
+  of local caching.
+
+  Operations not suitable for local caching. Like
+  put-index!, query-index, watch-index and watch-documents
+  dispatch directly to the underlying rest client.
+
+  Optionally takes a map of options.
+  :replicated? is used to find replicated endpoints.
+  :master-only-writes? is used to indicate that write operations only go to the master"
+  [url database options]
+  (let [rest-client (rest/rest-client url database options)
+        {:keys [put-index! query-index watch-index watch-documents]} rest-client
+        caching {:caching? true
+                 :rest-client rest-client
+                 :load-documents load-documents
+                 :bulk-operations! bulk-operations!
+                 :put-document! put-document!
+                 :put-index! put-index!
+                 :query-index query-index
+                 :watch-index watch-index
+                 :watch-documents watch-documents}]
+    (merge rest-client caching)))

--- a/src/clj_ravendb/client.clj
+++ b/src/clj_ravendb/client.clj
@@ -1,5 +1,6 @@
 (ns clj-ravendb.client
-  (:require [clj-ravendb.rest :refer :all]))
+  (:require [clj-ravendb.rest :refer [rest-client]]
+            [clj-ravendb.caching :refer [caching-client]]))
 
 (defn client
   "Gets a client for a RavenDB endpoint at the
@@ -7,11 +8,14 @@
 
   Optionally takes a map of options.
   :replicated? is used to find replicated endpoints.
-  :master-only-writes? is used to indicate that write operations only go to the master"
+  :master-only-writes? is used to indicate that write operations only go to the master
+  :caching? is used to indicate if documents should be cached locally"
   ([url database]
    (client url database {}))
-  ([url database options]
-   (rest-client url database options)))
+  ([url database {:keys [caching?] :as options}]
+   (if caching?
+     (caching-client url database options)
+     (rest-client url database options))))
 
 (defn load-documents
   [{:keys [load-documents] :as client} & args]

--- a/src/clj_ravendb/client.clj
+++ b/src/clj_ravendb/client.clj
@@ -94,7 +94,7 @@
        (wrap-retry-replicas post-req)
        (response-parser))))
 
-(defn bulk-operations
+(defn bulk-operations!
   "Handles a given set of bulk operations that
   correspond to RavenDB batch req.
 
@@ -102,7 +102,7 @@
   :request-builder is a custom request builder fn.
   :response-parser is a customer response parser fn."
   ([client operations]
-   (bulk-operations client operations {}))
+   (bulk-operations! client operations {}))
   ([{:keys [master-only-writes?] :as client}
     operations
     {:keys [request-builder response-parser]
@@ -119,7 +119,7 @@
                         (no-retry-replicas request post-req)
                         (wrap-retry-replicas request post-req))))))
 
-(defn put-index
+(defn put-index!
   "Creates or updates an index, where an index takes
   the form:
   idx {
@@ -133,7 +133,7 @@
   :request-builder is a custom request builder fn.
   :response-parser is a customer response parser fn."
   ([client index]
-   (put-index client index {}))
+   (put-index! client index {}))
   ([client index
     {:keys [request-builder response-parser]
      :or {request-builder req/put-index response-parser res/put-index}}]
@@ -143,7 +143,7 @@
        (put-req)
        (response-parser))))
 
-(defn put-document
+(defn put-document!
   "Creates or updates a document by its key. Where 'document'
   is a map.
 
@@ -151,7 +151,7 @@
   :request-builder is a custom request builder fn.
   :response-parser is a customer response parser fn."
   ([client key document]
-   (put-document client key document {}))
+   (put-document! client key document {}))
   ([{:keys [master-only-writes?] :as client}
     key document
     {:keys [request-builder response-parser]

--- a/src/clj_ravendb/client.clj
+++ b/src/clj_ravendb/client.clj
@@ -1,54 +1,5 @@
 (ns clj-ravendb.client
-  (:require [clj-http.client :as http]
-            [clj-ravendb.requests :as req]
-            [clojure.core.async :refer [go chan close! timeout <!! >!! <! >!]]
-            [clj-ravendb.responses :as res]))
-
-(def ^:dynamic *debug* false)
-(defmacro debug-do [& body]
-  (when *debug*
-    `(do ~@body)))
-
-(def not-nil? (complement nil?))
-
-(defn- post-req
-  [{:keys [url body]}]
-  (debug-do (println "Sending HTTP POST to" url "with JSON body " body))
-  (http/post url {:body body :as :json-string-keys}))
-
-(defn- put-req
-  [{:keys [url body]}]
-  (debug-do (println "Sending HTTP PUT to" url "with JSON body " body))
-  (http/put url {:body body :as :json-string-keys}))
-
-(defn- get-req
-  [{:keys [url]}]
-  (debug-do (println "Sending HTTP GET to" url))
-  (http/get url {:as :json-string-keys}))
-
-(defn- is-valid-client?
-  [{:keys [address replications replicated? master-only-writes?]}]
-  {:pre [(not-nil? address) (not-nil? replications)
-         (not-nil? replicated?) (not-nil? master-only-writes?)]}
-  true)
-
-(defn- no-retry-replicas
-  [{:keys [urls] :as request} handle]
-  (handle (merge {:url (first urls)} request)))
-
-(defn- wrap-retry-replicas
-  [request handle]
-  (loop [urls (:urls request)]
-    (let [response (try
-                     (handle (merge {:url (first urls)} request))
-                     (catch java.net.ConnectException ce
-                       (debug-do (println "Failed to execute request using " (first urls)))))]
-      (if (not (nil? response))
-        response
-        (recur (rest urls))))))
-
-(def client?
-  (memoize (fn [client] (is-valid-client? client))))
+  (:require [clj-ravendb.rest :refer :all]))
 
 (defn client
   "Gets a client for a RavenDB endpoint at the
@@ -59,194 +10,33 @@
   :master-only-writes? is used to indicate that write operations only go to the master"
   ([url database]
    (client url database {}))
-  ([url database {:keys [replicated? master-only-writes?]
-                  :or {replicated? false master-only-writes? true}}]
-   (let [fragments (list url "Databases" database)
-         address (clojure.string/join "/" fragments)
-         load-replications (fn []
-                             (debug-do (println "Loading replication destinations from" address))
-                             (:results (res/load-replications (get-req (req/load-replications address)))))
-         replications (if replicated?
-                        (load-replications)
-                        '())]
-    {:replicated? replicated?
-     :master-only-writes? master-only-writes?
-     :address address
-     :replications (map (fn
-                          [r]
-                          (let [fragments (list r "Databases" database)]
-                            (clojure.string/join "/" fragments))) replications)})))
+  ([url database options]
+   (rest-client url database options)))
 
 (defn load-documents
-  "Loads a collection of documents represented
-  by the given document ids.
-
-  Optionally takes a map of options.
-  :request-builder is a custom request builder fn.
-  :response-parser is a customer response parser fn."
-  ([client document-ids]
-   (load-documents client document-ids {}))
-  ([client document-ids
-    {:keys [request-builder response-parser]
-     :or {request-builder req/load-documents response-parser res/load-documents}}]
-   {:pre [(client? client) (not-empty document-ids)]}
-   (-> (request-builder client document-ids)
-       (wrap-retry-replicas post-req)
-       (response-parser))))
-
-(defn bulk-operations!
-  "Handles a given set of bulk operations that
-  correspond to RavenDB batch req.
-
-  Optionally takes a map of options.
-  :request-builder is a custom request builder fn.
-  :response-parser is a customer response parser fn."
-  ([client operations]
-   (bulk-operations! client operations {}))
-  ([{:keys [master-only-writes?] :as client}
-    operations
-    {:keys [request-builder response-parser]
-     :or {request-builder req/bulk-operations response-parser res/bulk-operations}}]
-   {:pre [(client? client)
-          (not-empty (filter
-                       (comp not nil?)
-                       (map (fn[{:keys [Method Document Metadata Key]}]
-                              (cond
-                                (= Method "PUT") (and Document Metadata Key)
-                                (= Method "DELETE") Key)) operations)))]}
-   (let [request (req/bulk-operations client operations)]
-     (response-parser (if master-only-writes?
-                        (no-retry-replicas request post-req)
-                        (wrap-retry-replicas request post-req))))))
-
-(defn put-index!
-  "Creates or updates an index, where an index takes
-  the form:
-  idx {
-    :name index-name
-    :alias document-alias
-    :where where-clause
-    :select projection
-  }
-
-  Optionally takes a map of options.
-  :request-builder is a custom request builder fn.
-  :response-parser is a customer response parser fn."
-  ([client index]
-   (put-index! client index {}))
-  ([client index
-    {:keys [request-builder response-parser]
-     :or {request-builder req/put-index response-parser res/put-index}}]
-   {:pre [(client? client)
-          (:name index) (:alias index) (:where index) (:select index)]}
-   (-> (request-builder client index)
-       (put-req)
-       (response-parser))))
+  [{:keys [load-documents] :as client} & args]
+  (apply load-documents client args))
 
 (defn put-document!
-  "Creates or updates a document by its key. Where 'document'
-  is a map.
-
-  Optionally takes a map of options.
-  :request-builder is a custom request builder fn.
-  :response-parser is a customer response parser fn."
-  ([client key document]
-   (put-document! client key document {}))
-  ([{:keys [master-only-writes?] :as client}
-    key document
-    {:keys [request-builder response-parser]
-     :or {request-builder req/put-document response-parser res/put-document}}]
-   {:pre [(client? client)]}
-   (let [request (request-builder client key document)]
-     (response-parser (if master-only-writes?
-                        (no-retry-replicas request post-req)
-                        (wrap-retry-replicas request post-req))))))
+  [{:keys [put-document!] :as client} & args]
+  (apply put-document! client args))
 
 (defn query-index
-  "Query an index, where the 'query' takes the form:
-  qry {
-    :index index-name
-    :x 1
-    :y 2
-  }.
+  [{:keys [query-index] :as client} & args]
+  (apply query-index client args))
 
-  Optionally takes a map of options.
-  :max-attempts is the maximum number of times to try
-  and hit a non stale index.
-  :wat is the time interval to wait before trying to
-  hit a non stale index.
-  :request-builder is a custom request builder fn.
-  :response-parser is a customer response parser fn."
-  ([client query]
-   (query-index client query {}))
-  ([client query {:keys [max-attempts wait request-builder response-parser]
-                    :or {max-attempts 5 wait 100
-                         request-builder req/query-index
-                         response-parser res/query-index}}]
-   {:pre [(client? client) (:index query)]}
-   (let [get-result (fn[]
-                      (-> (request-builder client query)
-                          (wrap-retry-replicas get-req)
-                          (response-parser)))]
-     (loop [result (get-result) attempt 0]
-       (if (or (not (:stale? result))
-               (= attempt max-attempts))
-         result
-         (do
-           (debug-do (println "Index" (:index query) "is stale, waiting" wait "ms before trying again."))
-           (Thread/sleep wait)
-           (recur (get-result) (inc attempt))))))))
+(defn put-index!
+  [{:keys [put-index!] :as client} & args]
+  (apply put-index! client args))
 
-(defn- watch
-  ([client watch-fn channel]
-   (watch client watch-fn channel {}))
-  ([client watch-fn channel {:keys [wait]
-                             :or {wait 500}}]
-   (let [keep-watching? (atom true)
-         f (future
-             (debug-do (println "Watching" watch "for changes"))
-             (loop [last-value {}]
-               (let [latest (watch-fn)]
-                 (if (and (not= last-value {})
-                          (not= last-value latest))
-                   (go (>! channel latest)))
-                 (if @keep-watching?
-                   (do
-                     (debug-do (println "Waiting" wait "ms until next 'watch'"))
-                     (Thread/sleep wait)
-                     (recur latest))))))]
-     {:channel channel
-      :stop (fn []
-              (debug-do (println "Closing channel" channel "and trying to end future" f))
-              (reset! keep-watching? false)
-              (close! channel))})))
+(defn bulk-operations!
+  [{:keys [bulk-operations!] :as client} & args]
+  (apply bulk-operations! client args))
 
 (defn watch-documents
-  "Watch a collections of documents for changes
-  and place the changed document(s) on a channel
-  when there are differences.
-
-  Options is a map and can contain,
-  :wait - milliseconds to wait between watch calls."
-  ([client document-ids]
-   (watch-documents client document-ids (chan)))
-  ([client document-ids channel]
-   (watch-documents client document-ids channel {}))
-  ([client document-ids channel options]
-   (watch client (fn []
-                   (load-documents client document-ids)) channel options)))
+  [{:keys [watch-documents] :as client} & args]
+  (apply watch-documents client args))
 
 (defn watch-index
-  "Watch the results of an index query for changes
-  and place the changed result(s) on a channel
-  when there are differences.
-
-  Options is a map and can contain,
-  :wait - milliseconds to wait between watch calls."
-  ([client query]
-   (watch-index client query (chan)))
-  ([client query channel]
-   (watch-index client query channel {}))
-  ([client query channel options]
-   (watch client (fn []
-                   (query-index client query)) channel options)))
+  [{:keys [watch-index] :as client} & args]
+  (apply watch-index client args))

--- a/src/clj_ravendb/replication.clj
+++ b/src/clj_ravendb/replication.clj
@@ -1,0 +1,31 @@
+(ns clj-ravendb.replication
+  (:require [clj-ravendb.util :refer :all]))
+
+(defn no-retry-replicas
+  "Given a request containing a list of urls capable of servicing
+  the request, this function will only execute handle against the
+  first url"
+  [{:keys [urls] :as request} handle]
+  (handle (merge {:url (first urls)} request)))
+
+(defn wrap-retry-replicas
+  "Given a request containing a list of urls capable of servicing
+  the request, this function will execute handle against each of the
+  urls"
+  [request handle]
+  (loop [urls (:urls request)]
+    (let [response (try
+                     (handle (merge {:url (first urls)} request))
+                     (catch java.net.ConnectException ce
+                       (debug-do (println "Failed to execute request using " (first urls)))))]
+      (if (not (nil? response))
+        response
+        (recur (rest urls))))))
+
+(defn map-replication-urls
+  "Given a collection of replication responses returns a sequence of
+  replication url for the given database"
+  [replications database]
+  (map (fn [r]
+         (let [fragments (list r "Databases" database)]
+           (clojure.string/join "/" fragments))) replications))

--- a/src/clj_ravendb/rest.clj
+++ b/src/clj_ravendb/rest.clj
@@ -1,0 +1,206 @@
+(ns clj-ravendb.rest
+  (:require [clj-ravendb.util :refer :all]
+            [clj-ravendb.replication :refer :all]
+            [clj-ravendb.requests :as req]
+            [clojure.core.async :refer [go chan close! timeout <!! >!! <! >!]]
+            [clj-ravendb.responses :as res]))
+
+(defn- load-documents
+  "Loads a collection of documents represented
+  by the given document ids.
+
+  Optionally takes a map of options.
+  :request-builder is a custom request builder fn.
+  :response-parser is a customer response parser fn."
+  ([client document-ids]
+   (load-documents client document-ids {}))
+  ([client document-ids
+    {:keys [request-builder response-parser]
+     :or {request-builder req/load-documents response-parser res/load-documents}}]
+   {:pre [(not-empty document-ids)]}
+   (-> (request-builder client document-ids)
+       (wrap-retry-replicas post-req)
+       (response-parser))))
+
+(defn- bulk-operations!
+  "Handles a given set of bulk operations that
+  correspond to RavenDB batch req.
+
+  Optionally takes a map of options.
+  :request-builder is a custom request builder fn.
+  :response-parser is a customer response parser fn."
+  ([client operations]
+   (bulk-operations! client operations {}))
+  ([{:keys [master-only-writes?] :as client}
+    operations
+    {:keys [request-builder response-parser]
+     :or {request-builder req/bulk-operations response-parser res/bulk-operations}}]
+   {:pre [(not-empty (filter
+                       (comp not nil?)
+                       (map (fn[{:keys [Method Document Metadata Key]}]
+                              (cond
+                                (= Method "PUT") (and Document Metadata Key)
+                                (= Method "DELETE") Key)) operations)))]}
+   (let [request (req/bulk-operations client operations)]
+     (response-parser (if master-only-writes?
+                        (no-retry-replicas request post-req)
+                        (wrap-retry-replicas request post-req))))))
+
+(defn- put-index!
+  "Creates or updates an index, where an index takes
+  the form:
+  idx {
+    :name index-name
+    :alias document-alias
+    :where where-clause
+    :select projection
+  }
+
+  Optionally takes a map of options.
+  :request-builder is a custom request builder fn.
+  :response-parser is a customer response parser fn."
+  ([client index]
+   (put-index! client index {}))
+  ([client index
+    {:keys [request-builder response-parser]
+     :or {request-builder req/put-index response-parser res/put-index}}]
+   {:pre [(:name index) (:alias index) (:where index) (:select index)]}
+   (-> (request-builder client index)
+       (put-req)
+       (response-parser))))
+
+(defn- put-document!
+  "Creates or updates a document by its key. Where 'document'
+  is a map.
+
+  Optionally takes a map of options.
+  :request-builder is a custom request builder fn.
+  :response-parser is a customer response parser fn."
+  ([client key document]
+   (put-document! client key document {}))
+  ([{:keys [master-only-writes?] :as client}
+    key document
+    {:keys [request-builder response-parser]
+     :or {request-builder req/put-document response-parser res/put-document}}]
+   (let [request (request-builder client key document)]
+     (response-parser (if master-only-writes?
+                        (no-retry-replicas request post-req)
+                        (wrap-retry-replicas request post-req))))))
+
+(defn- query-index
+  "Query an index, where the 'query' takes the form:
+  qry {
+    :index index-name
+    :x 1
+    :y 2
+  }.
+
+  Optionally takes a map of options.
+  :max-attempts is the maximum number of times to try
+  and hit a non stale index.
+  :wat is the time interval to wait before trying to
+  hit a non stale index.
+  :request-builder is a custom request builder fn.
+  :response-parser is a customer response parser fn."
+  ([client query]
+   (query-index client query {}))
+  ([client query {:keys [max-attempts wait request-builder response-parser]
+                    :or {max-attempts 5 wait 100
+                         request-builder req/query-index
+                         response-parser res/query-index}}]
+   {:pre [(:index query)]}
+   (let [get-result (fn[]
+                      (-> (request-builder client query)
+                          (wrap-retry-replicas get-req)
+                          (response-parser)))]
+     (loop [result (get-result) attempt 0]
+       (if (or (not (:stale? result))
+               (= attempt max-attempts))
+         result
+         (do
+           (debug-do (println "Index" (:index query) "is stale, waiting" wait "ms before trying again."))
+           (Thread/sleep wait)
+           (recur (get-result) (inc attempt))))))))
+
+(defn- watch
+  ([client watch-fn channel]
+   (watch client watch-fn channel {}))
+  ([client watch-fn channel {:keys [wait]
+                             :or {wait 500}}]
+   (let [keep-watching? (atom true)
+         f (future
+             (debug-do (println "Watching" watch "for changes"))
+             (loop [last-value {}]
+               (let [latest (watch-fn)]
+                 (if (and (not= last-value {})
+                          (not= last-value latest))
+                   (go (>! channel latest)))
+                 (if @keep-watching?
+                   (do
+                     (debug-do (println "Waiting" wait "ms until next 'watch'"))
+                     (Thread/sleep wait)
+                     (recur latest))))))]
+     {:channel channel
+      :stop (fn []
+              (debug-do (println "Closing channel" channel "and trying to end future" f))
+              (reset! keep-watching? false)
+              (close! channel))})))
+
+(defn- watch-documents
+  "Watch a collections of documents for changes
+  and place the changed document(s) on a channel
+  when there are differences.
+
+  Options is a map and can contain,
+  :wait - milliseconds to wait between watch calls."
+  ([client document-ids]
+   (watch-documents client document-ids (chan)))
+  ([client document-ids channel]
+   (watch-documents client document-ids channel {}))
+  ([client document-ids channel options]
+   (watch client (fn []
+                   (load-documents client document-ids)) channel options)))
+
+(defn- watch-index
+  "Watch the results of an index query for changes
+  and place the changed result(s) on a channel
+  when there are differences.
+
+  Options is a map and can contain,
+  :wait - milliseconds to wait between watch calls."
+  ([client query]
+   (watch-index client query (chan)))
+  ([client query channel]
+   (watch-index client query channel {}))
+  ([client query channel options]
+   (watch client (fn []
+                   (query-index client query)) channel options)))
+
+(defn rest-client
+  "Gets a client for a RavenDB endpoint at the
+  given url and database.
+
+  Optionally takes a map of options.
+  :replicated? is used to find replicated endpoints.
+  :master-only-writes? is used to indicate that write operations only go to the master"
+  [url database {:keys [replicated? master-only-writes?]
+                 :or {replicated? false master-only-writes? true}}]
+  (let [fragments (list url "Databases" database)
+        address (clojure.string/join "/" fragments)
+        load-replications (fn []
+                            (debug-do (println "Loading replication destinations from" address))
+                            (:results (res/load-replications (get-req (req/load-replications address)))))
+        replications (if replicated?
+                       (load-replications)
+                       '())]
+    {:replicated? replicated?
+     :master-only-writes? master-only-writes?
+     :address address
+     :replications (map-replication-urls replications database)
+     :load-documents load-documents
+     :bulk-operations! bulk-operations!
+     :put-document! put-document!
+     :put-index! put-index!
+     :query-index query-index
+     :watch-index watch-index
+     :watch-documents watch-documents}))

--- a/src/clj_ravendb/rest.clj
+++ b/src/clj_ravendb/rest.clj
@@ -35,12 +35,12 @@
     operations
     {:keys [request-builder response-parser]
      :or {request-builder req/bulk-operations response-parser res/bulk-operations}}]
-   {:pre [(not-empty (filter
+   {:pre [(= (count (filter
                        (comp not nil?)
                        (map (fn[{:keys [Method Document Metadata Key]}]
                               (cond
                                 (= Method "PUT") (and Document Metadata Key)
-                                (= Method "DELETE") Key)) operations)))]}
+                                (= Method "DELETE") Key)) operations))) (count operations))]}
    (let [request (req/bulk-operations client operations)]
      (response-parser (if master-only-writes?
                         (no-retry-replicas request post-req)

--- a/src/clj_ravendb/util.clj
+++ b/src/clj_ravendb/util.clj
@@ -1,0 +1,24 @@
+(ns clj-ravendb.util
+  (:require [clj-http.client :as http]))
+
+(def ^:dynamic *debug* false)
+(defmacro debug-do [& body]
+  (when *debug*
+    `(do ~@body)))
+
+(def not-nil? (complement nil?))
+
+(defn post-req
+  [{:keys [url body]}]
+  (debug-do (println "Sending HTTP POST to" url "with JSON body " body))
+  (http/post url {:body body :as :json-string-keys}))
+
+(defn put-req
+  [{:keys [url body]}]
+  (debug-do (println "Sending HTTP PUT to" url "with JSON body " body))
+  (http/put url {:body body :as :json-string-keys}))
+
+(defn get-req
+  [{:keys [url]}]
+  (debug-do (println "Sending HTTP GET to" url))
+  (http/get url {:as :json-string-keys}))

--- a/test/clj_ravendb/client_caching_test.clj
+++ b/test/clj_ravendb/client_caching_test.clj
@@ -1,20 +1,24 @@
 (ns clj-ravendb.client-caching-test
   (:require [clojure.test :refer :all]
             [clj-ravendb.client :refer :all]
+            [clj-ravendb.caching :refer [client-cache]]
             [clj-ravendb.requests :as req]
             [clj-ravendb.responses :as res]
             [clj-ravendb.config :refer :all]
             [clojure.pprint :as pprint]))
 
-(comment (let [client (client ravendb-url ravendb-database {:caching? true})]
+(let [client (client ravendb-url ravendb-database {:caching? true})
+      _ (pprint/pprint client)]
   (deftest test-load-documents-returns-correct-results
     (testing "documents loaded from cache have a :cached? flag"
       (let [doc-ids ["employees/1"]
             _ (load-documents client doc-ids)
-            actual (load-documents client doc-ids)
+            actual (load-documents client (conj doc-ids "employees/2"))
             results (actual :results)
-            doc (first results)]
-        (is (:cached? doc))))
+            doc (first results)
+            doc-2 (second results)]
+        (is (:cached? doc))
+        (is (nil? (:cached doc-2)))))
     (testing "documents loaded get added to the cache"
       (let [doc-ids ["employees/2"]
             _ (load-documents client doc-ids)
@@ -27,14 +31,29 @@
             doc (first (filter (fn [d]
                                  (= (:key d) doc-id)) @client-cache))]
         (is (= doc-id (:key doc)))))
-    (testing "deleted documents get removed from the cache"
+    (testing "bulk operations result in add and remove from the cache"
       (let [doc-id "Key1"
+            doc-id-2 "Key2"
+            doc-id-3 "Key3"
             _ (put-document! client doc-id {})
+            _ (put-document! client doc-id-2 {})
             _ (bulk-operations! client [{:Method "DELETE"
-                                        :Key doc-id}])
+                                         :Key doc-id}
+                                        {:Method "PUT"
+                                         :Document {}
+                                         :Metadata {}
+                                         :Key doc-id-3}])
             doc (first (filter (fn [d]
-                                 (= (:key d) doc-id)) @client-cache))]
-        (is (nil? doc)))))
+                                 (= (:key d) doc-id)) @client-cache))
+            doc2 (first (filter (fn [d]
+                                 (= (:key d) doc-id-2)) @client-cache))
+            doc3 (first (filter (fn [d]
+                                 (= (:key d) doc-id-3)) @client-cache))]
+        (is (nil? doc))
+        (is (= doc-id-2 (:key doc2)))
+        (is (= doc-id-3 (:key doc3))))))
 
   (use-fixtures :each (fn [f] (f) (bulk-operations! client [{:Method "DELETE"
-                                                            :Key "Key1"}])))))
+                                                             :Key "Key1"}
+                                                            {:Method "DELETE"
+                                                             :Key "Key2"}]))))

--- a/test/clj_ravendb/client_caching_test.clj
+++ b/test/clj_ravendb/client_caching_test.clj
@@ -31,6 +31,15 @@
             doc (first (filter (fn [d]
                                  (= (:key d) doc-id)) @client-cache))]
         (is (= doc-id (:key doc)))))
+    (testing "put documents get updated in the cache"
+      (let [doc-id "Key1"
+            _ (put-document! client doc-id {})
+            _ (put-document! client doc-id {:updated 1})
+            doc (first (filter (fn [d]
+                                 (= (:key d) doc-id)) @client-cache))
+            _ (println doc)]
+        (is (and (= doc-id (:key doc))
+                 (= 1 (:updated doc))))))
     (testing "bulk operations result in add and remove from the cache"
       (let [doc-id "Key1"
             doc-id-2 "Key2"

--- a/test/clj_ravendb/client_caching_test.clj
+++ b/test/clj_ravendb/client_caching_test.clj
@@ -1,0 +1,40 @@
+(ns clj-ravendb.client-caching-test
+  (:require [clojure.test :refer :all]
+            [clj-ravendb.client :refer :all]
+            [clj-ravendb.requests :as req]
+            [clj-ravendb.responses :as res]
+            [clj-ravendb.config :refer :all]
+            [clojure.pprint :as pprint]))
+
+(comment (let [client (client ravendb-url ravendb-database {:caching? true})]
+  (deftest test-load-documents-returns-correct-results
+    (testing "documents loaded from cache have a :cached? flag"
+      (let [doc-ids ["employees/1"]
+            _ (load-documents client doc-ids)
+            actual (load-documents client doc-ids)
+            results (actual :results)
+            doc (first results)]
+        (is (:cached? doc))))
+    (testing "documents loaded get added to the cache"
+      (let [doc-ids ["employees/2"]
+            _ (load-documents client doc-ids)
+            doc (first (filter (fn [d]
+                                 (= (:key d) "employees/2")) @client-cache))]
+        (is (= "employees/2" (:key doc)))))
+    (testing "put documents get added to the cache"
+      (let [doc-id "Key1"
+            _ (put-document! client doc-id {})
+            doc (first (filter (fn [d]
+                                 (= (:key d) doc-id)) @client-cache))]
+        (is (= doc-id (:key doc)))))
+    (testing "deleted documents get removed from the cache"
+      (let [doc-id "Key1"
+            _ (put-document! client doc-id {})
+            _ (bulk-operations! client [{:Method "DELETE"
+                                        :Key doc-id}])
+            doc (first (filter (fn [d]
+                                 (= (:key d) doc-id)) @client-cache))]
+        (is (nil? doc)))))
+
+  (use-fixtures :each (fn [f] (f) (bulk-operations! client [{:Method "DELETE"
+                                                            :Key "Key1"}])))))

--- a/test/clj_ravendb/client_putting_documents_test.clj
+++ b/test/clj_ravendb/client_putting_documents_test.clj
@@ -11,7 +11,7 @@
     (testing "processing a PUT command returns the correct result"
       (let [key "Key1"
             document {:name "Test"}
-            actual (put-document client key document) expected 200]
+            actual (put-document! client key document) expected 200]
         (pprint/pprint actual)
         (is (= expected (actual :status))))))
 
@@ -22,7 +22,7 @@
             req-builder (fn [client key document]
                           (throw (Exception. "CustomRequestBuilderError")))]
         (is (thrown-with-msg? Exception #"CustomRequestBuilderError" 
-                              (put-document client key document 
+                              (put-document! client key document 
                                             {:request-builder req-builder 
                                              :response-parser res/put-document}))))))
   
@@ -33,9 +33,9 @@
             res-parser (fn [raw-response]
                           (throw (Exception. "CustomResponseParserError")))]
         (is (thrown-with-msg? Exception #"CustomResponseParserError" 
-                              (put-document client key document 
+                              (put-document! client key document 
                                             {:request-builder req/put-document 
                                              :response-parser res-parser}))))))
 
-  (use-fixtures :each (fn [f] (f) (bulk-operations client [{:Method "DELETE"
+  (use-fixtures :each (fn [f] (f) (bulk-operations! client [{:Method "DELETE"
                                                             :Key "Key1"}]))))

--- a/test/clj_ravendb/client_putting_indexes_test.clj
+++ b/test/clj_ravendb/client_putting_indexes_test.clj
@@ -11,21 +11,21 @@
   (deftest test-put-index-with-invalid-index-throws
     (testing "Putting an index with an invalid form."
       (is (thrown? AssertionError
-                   (put-index client {})))
+                   (put-index! client {})))
       (is (thrown? AssertionError
-                   (put-index client {:name "Test"})))
+                   (put-index! client {:name "Test"})))
       (is (thrown? AssertionError
-                   (put-index client {:select "Test"})))
+                   (put-index! client {:select "Test"})))
       (is (thrown? AssertionError
-                   (put-index client {:where "Test"})))
+                   (put-index! client {:where "Test"})))
       (is (thrown? AssertionError
-                   (put-index client {:name "Test" :alias "Alias"})))
+                   (put-index! client {:name "Test" :alias "Alias"})))
       (is (thrown? AssertionError
-                   (put-index client {:name "Test" :alias "Alias" :where "Where"})))))
+                   (put-index! client {:name "Test" :alias "Alias" :where "Where"})))))
 
   (deftest test-put-index-returns-correct-status-code
     (testing "putting an index returns the correct status code"
-      (let [actual (put-index client idx)
+      (let [actual (put-index! client idx)
             expected 201]
         (pprint/pprint actual)
         (is (= expected (actual :status))))))
@@ -35,7 +35,7 @@
       (let [req-builder (fn [url index]
                           (throw (Exception. "CustomRequestBuilderError")))]
         (is (thrown-with-msg? Exception #"CustomRequestBuilderError"
-                              (put-index client idx
+                              (put-index! client idx
                                          {:request-builder req-builder
                                           :response-parser res/query-index}))))))
 
@@ -44,6 +44,6 @@
       (let [res-parser (fn [raw-response]
                          (throw (Exception. "CustomResponseParserError")))]
         (is (thrown-with-msg? Exception #"CustomResponseParserError"
-                              (put-index client idx
+                              (put-index! client idx
                                          {:request-builder req/put-index
                                           :response-parser res-parser})))))))

--- a/test/clj_ravendb/client_watching_test.clj
+++ b/test/clj_ravendb/client_watching_test.clj
@@ -15,7 +15,7 @@
             ch (chan)
             watcher (watch-documents client ["TestDocToWatch"] ch {:wait 0})
             _ (Thread/sleep 1000)
-            _ (put-document client key document) 
+            _ (put-document! client key document) 
             actual (first (:results (<!! ch)))] 
         ((:stop watcher))   
         (is (= actual {:key key :doc document})))))
@@ -27,20 +27,20 @@
             ch (chan)
             watcher (watch-index client {:index "WatchedDocuments"} ch {:wait 0})
             _ (Thread/sleep 1000)
-            _ (put-document client key document) 
+            _ (put-document! client key document) 
             actual (first (:results (<!! ch)))]
         ((:stop watcher))   
         (is (= actual document)))))
 
   (use-fixtures :each (fn [f] 
-                        (put-index client {:name "WatchedDocuments" 
+                        (put-index! client {:name "WatchedDocuments" 
                                            :alias "doc" 
                                            :where "doc.name ==\"WatchedDocument\"" 
                                            :select "new { doc.name }"}) 
-                        (bulk-operations client [{:Method "PUT"
+                        (bulk-operations! client [{:Method "PUT"
                                                   :Key "TestDocToWatch"
                                                   :Document {:test 1 :name "WatchedDocument"}
                                                   :Metadata {}}])
                         (f) 
-                        (bulk-operations client [{:Method "DELETE"
+                        (bulk-operations! client [{:Method "DELETE"
                                                   :Key "TestDocToWatch"}]))))


### PR DESCRIPTION
This pull request adds a cache aware version of the RavenDB client. 

`load-documents`, `put-document!`,`bulk-operations!` are cachable operations that update `clj-ravendb.caching client-cache`.

The cache aware version of the client dispatches requests to the regular rest client but also applies caching.
