### PR TITLE
Oauth support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: clojure
+lein: lein2
+script: lein2 all do clean, test
+branches:
+  only:
+    - master
+jdk:
+  - openjdk6
+  - openjdk7
+  - oraclejdk7

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :plugins [[quickie "0.2.5"]]
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [clj-http "0.9.2"]
+                 [cheshire "5.4.0"]
                  [org.clojure/core.async "0.1.303.0-886421-alpha"]
                  [org.clojure/data.json "0.2.3"]]
   :deploy-repositories [

--- a/src/clj_ravendb/requests.clj
+++ b/src/clj_ravendb/requests.clj
@@ -1,5 +1,6 @@
 (ns clj-ravendb.requests
-  (:require [clojure.data.json :as json]))
+  (:require [clojure.data.json :as json]
+            [cheshire.core :refer [generate-string]]))
 
 (defn- all-urls
   [master replicas url]
@@ -7,28 +8,44 @@
         urls (cons (str master url) urls)]
   urls))
 
+(defn- get-token-headers
+  [enable-oauth? api-key]
+  (if enable-oauth?
+    {"Api-Key" api-key
+     "grant_type" "client_credentials"}
+    {}))
+
+(defn- oauth-headers
+  [enable-oauth? token]
+  (if enable-oauth?
+    {"Authorization" (str "Bearer " (generate-string token))}
+    {}))
+
 (defn load-documents
   "Generates a map that represents a http request
   to the queries endpoint in order to load documents"
-  [{:keys [address replications]} document-ids]
-  {:urls (all-urls address replications "/Queries")
+  [{:keys [address replications enable-oauth? oauth-header ssl-insecure?]} document-ids]
+  {:ssl-insecure? ssl-insecure?
+   :urls (all-urls address replications "/Queries")
    :body (json/write-str document-ids)})
 
 (defn query-index
   "Generates a map that represents a http request
   to the indexes endpoint in order to query an index."
-  [{:keys [address replications]} qry]
+  [{:keys [address replications ssl-insecure?]} qry]
   (let [request-url (str "/indexes/" (qry :index) "?query=")
         criteria (clojure.string/join " AND " (vec (for [[k v] (dissoc qry :index)]
                                                      (str (name k) ":" v))))]
-    {:urls (all-urls address replications (str request-url criteria))}))
+    {:ssl-insecure? ssl-insecure?
+     :urls (all-urls address replications (str request-url criteria))}))
 
 (defn bulk-operations
   "Generates a map that represents a http request
   to the bulk_docs endpoint in order run document operations."
-  [{:keys [address replications]} operations]
+  [{:keys [address replications ssl-insecure?]} operations]
   (let [request-url (str address "/bulk_docs")]
     {:urls (all-urls address replications "/bulk_docs")
+     :ssl-insecure? ssl-insecure?
      :body (json/write-str (map (fn [{:keys [method id document metadata]}]
                                   {:Method method
                                    :Key id
@@ -47,9 +64,10 @@
 (defn put-index
   "Generates a map that represents a http request
   to the indexes endpoint in order to put an index."
-  [{:keys [address]} {:keys [name alias where select]}]
+  [{:keys [address ssl-insecure?]} {:keys [name alias where select]}]
   (let [request-url (str address "/indexes/" name)]
     {:url request-url
+     :ssl-insecure? ssl-insecure?
      :body (json/write-str {:Map (str
                                    "from " alias " in docs"
                                    " where " where
@@ -58,18 +76,33 @@
 (defn load-replications
   "Generates a map that represents a http request
   to the replication endpoint in order to find replication endpoints."
-  [url]
-  (let [request-url (str url "/docs/Raven/Replication/Destinations")]
-    {:url request-url}))
+  [{:keys [address ssl-insecure?]}]
+  (let [request-url (str address "/docs/Raven/Replication/Destinations")]
+    {:url request-url
+     :ssl-insecure? ssl-insecure?}))
 
 (defn stats
   "Generates a map that represents a http request
   to the /stats RavenDB endpoint"
-  [{:keys [address replications]}]
-  {:urls (all-urls address replications "/stats")})
+  [{:keys [address replications ssl-insecure?]}]
+  {:ssl-insecure? ssl-insecure?
+   :urls (all-urls address replications "/stats")})
 
 (defn user-info
   "Generates a map that represents a http request
   to the /debug/user-info RavenDB endpoint"
-  [{:keys [address replications]}]
-  {:urls (all-urls address replications "/debug/user-info")})
+  [{:keys [address replications ssl-insecure?]}]
+  {:ssl-insecure? ssl-insecure?
+   :urls (all-urls address replications "/debug/user-info")})
+
+(defn oauth-token
+  "Generates a map that represents a http request
+  to the /ApiKeys/OAuth/AccessToken RavenDB endpoint"
+  [{:keys [address replications enable-oauth? api-key ssl-insecure?]}]
+  {:headers (get-token-headers enable-oauth? api-key)
+   :ssl-insecure? ssl-insecure?
+   :url (str address "/OAuth/AccessToken")})
+
+(defn wrap-oauth-header
+  [request enable-oauth? oauth-header]
+  (merge request {:headers (oauth-headers enable-oauth? oauth-header)}))

--- a/src/clj_ravendb/responses.clj
+++ b/src/clj_ravendb/responses.clj
@@ -9,7 +9,8 @@
                          v)])) )
 
 (defn load-replications
-  [{:keys [body status]}]
+  [{:keys [body status] :as r}]
+  (println r)
   (let [results (body "Destinations")
         mapped (map (fn[i] (i "Url")) results)]
     {:status status

--- a/src/clj_ravendb/rest.clj
+++ b/src/clj_ravendb/rest.clj
@@ -15,11 +15,12 @@
   :response-parser is a customer response parser fn."
   ([client document-ids]
    (load-documents client document-ids {}))
-  ([client document-ids
+  ([{:keys [enable-oauth? oauth-header] :as client} document-ids
     {:keys [request-builder response-parser]
      :or {request-builder req/load-documents response-parser res/load-documents}}]
    {:pre [(not-empty document-ids)]}
    (-> (request-builder client document-ids)
+       (req/wrap-oauth-header enable-oauth? oauth-header)
        (wrap-retry-replicas post-req)
        (response-parser))))
 
@@ -32,12 +33,12 @@
   :response-parser is a customer response parser fn."
   ([client operations]
    (bulk-operations! client operations {}))
-  ([{:keys [master-only-writes?] :as client}
+  ([{:keys [master-only-writes? enable-oauth? oauth-header] :as client}
     operations
     {:keys [request-builder response-parser]
      :or {request-builder req/bulk-operations response-parser res/bulk-operations}}]
    {:pre [(valid/validate-bulk-operations operations)]}
-   (let [request (request-builder client operations)]
+   (let [request (req/wrap-oauth-header (request-builder client operations) enable-oauth? oauth-header)]
      (response-parser (if master-only-writes?
                         (no-retry-replicas request post-req)
                         (wrap-retry-replicas request post-req))))))
@@ -57,11 +58,13 @@
   :response-parser is a customer response parser fn."
   ([client index]
    (put-index! client index {}))
-  ([client index
+  ([{:keys [enable-oauth? oauth-header] :as client}
+    index
     {:keys [request-builder response-parser]
      :or {request-builder req/put-index response-parser res/put-index}}]
    {:pre [(:name index) (:alias index) (:where index) (:select index)]}
    (-> (request-builder client index)
+       (req/wrap-oauth-header enable-oauth? oauth-header)
        (put-req)
        (response-parser))))
 
@@ -97,14 +100,17 @@
   :response-parser is a customer response parser fn."
   ([client query]
    (query-index client query {}))
-  ([client query {:keys [max-attempts wait request-builder response-parser]
-                    :or {max-attempts 5 wait 100
-                         request-builder req/query-index
-                         response-parser res/query-index}}]
+  ([{:keys [enable-oauth? oauth-header] :as client}
+    query
+    {:keys [max-attempts wait request-builder response-parser]
+     :or {max-attempts 5 wait 100
+          request-builder req/query-index
+          response-parser res/query-index}}]
    {:pre [(:index query)]}
    (let [get-result #(-> (request-builder client query)
-                          (wrap-retry-replicas get-req)
-                          (response-parser))]
+                         (req/wrap-oauth-header enable-oauth? oauth-header)
+                         (wrap-retry-replicas get-req)
+                         (response-parser))]
      (loop [result (get-result) attempt 0]
        (if (or (not (:stale? result))
                (= attempt max-attempts))
@@ -178,10 +184,10 @@
   :response-parser is a customer response parser fn."
   ([client]
    (stats client {}))
-  ([{:keys [master-only-writes?] :as client}
+  ([{:keys [master-only-writes? enable-oauth? oauth-header] :as client}
     {:keys [request-builder response-parser]
      :or {request-builder req/stats response-parser res/stats}}]
-   (let [request (request-builder client)]
+   (let [request (req/wrap-oauth-header (request-builder client) enable-oauth? oauth-header)]
      (response-parser (wrap-retry-replicas request get-req)))))
 
 (defn- user-info
@@ -194,10 +200,10 @@
   :response-parser is a customer response parser fn."
   ([client]
    (user-info client {}))
-  ([{:keys [master-only-writes?] :as client}
+  ([{:keys [master-only-writes? enable-oauth? oauth-header] :as client}
     {:keys [request-builder response-parser]
      :or {request-builder req/user-info response-parser res/user-info}}]
-   (let [request (request-builder client)]
+   (let [request (req/wrap-oauth-header (request-builder client) enable-oauth? oauth-header)]
      (response-parser (wrap-retry-replicas request get-req)))))
 
 (defn rest-client
@@ -207,18 +213,22 @@
   Optionally takes a map of options.
   :replicated? is used to find replicated endpoints.
   :master-only-writes? is used to indicate that write operations only go to the master"
-  [url database {:keys [replicated? master-only-writes?]
-                 :or {replicated? false master-only-writes? true}}]
+  [url database {:keys [replicated? master-only-writes? enable-oauth? oauth-url api-key ssl-insecure?]
+                 :or {replicated? false master-only-writes? true enable-oauth? true oauth-url "https://amazon-useast-2-oauth.ravenhq.com" api-key "a670daab-d226-49ea-8afb-a065faedd628" ssl-insecure? false}}]
   (let [fragments (list url "Databases" database)
         address (clojure.string/join "/" fragments)
+        oauth (get-req (req/oauth-token {:address oauth-url :enable-oauth? enable-oauth? :api-key api-key :ssl-insecure? ssl-insecure?}))
         load-replications (fn []
                             (debug-do (println "Loading replication destinations from" address))
-                            (:results (res/load-replications (get-req (req/load-replications address)))))
+                            (:results (res/load-replications (get-req (req/wrap-oauth-header (req/load-replications {:address address :ssl-insecure? ssl-insecure?}) enable-oauth? (:body oauth))))))
         replications (if replicated?
                        (load-replications)
                        '())]
     {:replicated? replicated?
      :master-only-writes? master-only-writes?
+     :enable-oauth? enable-oauth?
+     :ssl-insecure? ssl-insecure?
+     :oauth-header (:body oauth)
      :address address
      :replications (map-replication-urls replications database)
      :load-documents load-documents

--- a/src/clj_ravendb/util.clj
+++ b/src/clj_ravendb/util.clj
@@ -9,16 +9,16 @@
 (def not-nil? (complement nil?))
 
 (defn post-req
-  [{:keys [url body]}]
+  [{:keys [url body headers ssl-insecure?]}]
   (debug-do (println "Sending HTTP POST to" url "with JSON body " body))
-  (http/post url {:body body :as :json-string-keys}))
+  (http/post url {:body body :headers headers :as :json-string-keys :insecure? ssl-insecure?}))
 
 (defn put-req
-  [{:keys [url body]}]
+  [{:keys [url body headers ssl-insecure?]}]
   (debug-do (println "Sending HTTP PUT to" url "with JSON body " body))
-  (http/put url {:body body :as :json-string-keys}))
+  (http/put url {:body body :headers headers :as :json-string-keys :insecure? ssl-insecure?}))
 
 (defn get-req
-  [{:keys [url]}]
+  [{:keys [url headers ssl-insecure?]}]
   (debug-do (println "Sending HTTP GET to" url))
-  (http/get url {:as :json-string-keys}))
+  (http/get url {:headers headers :as :json-string-keys :insecure? ssl-insecure?}))

--- a/test/clj_ravendb/client_bulk_operations_test.clj
+++ b/test/clj_ravendb/client_bulk_operations_test.clj
@@ -5,7 +5,7 @@
             [clj-ravendb.responses :as res]
             [clj-ravendb.config :refer :all]))
 
-(let [client (client ravendb-url ravendb-database)]
+(let [client (client ravendb-url ravendb-database {:ssl-insecure? true})]
   (deftest test-bulk-operations-with-no-operations
     (testing "Bulk operations without specifying any operations
              throws an assertion error."

--- a/test/clj_ravendb/client_bulk_operations_test.clj
+++ b/test/clj_ravendb/client_bulk_operations_test.clj
@@ -5,7 +5,7 @@
             [clj-ravendb.responses :as res]
             [clj-ravendb.config :refer :all]))
 
-(let [client (client ravendb-url ravendb-database {:ssl-insecure? true})]
+(let [client (client ravendb-url ravendb-database {:ssl-insecure? true :oauth-url oauth-url :api-key api-key})]
   (deftest test-bulk-operations-with-no-operations
     (testing "Bulk operations without specifying any operations
              throws an assertion error."

--- a/test/clj_ravendb/client_caching_test.clj
+++ b/test/clj_ravendb/client_caching_test.clj
@@ -6,7 +6,7 @@
             [clj-ravendb.responses :as res]
             [clj-ravendb.config :refer :all]))
 
-(let [client (client ravendb-url ravendb-database {:caching? true :ssl-insecure? true})]
+(let [client (client ravendb-url ravendb-database {:caching? true :ssl-insecure? true :oauth-url oauth-url :api-key api-key})]
   (deftest test-load-documents-returns-correct-results
     (testing "documents loaded from cache have a :cached? flag"
       (let [doc-ids ["employees/1"]
@@ -65,4 +65,6 @@
   (use-fixtures :each (fn [f] (f) (bulk-operations! client [{:method "DELETE"
                                                              :id "Key1"}
                                                             {:method "DELETE"
-                                                             :id "Key2"}]))))
+                                                             :id "Key2"}
+                                                            {:method "DELETE"
+                                                             :id "Key3"}]))))

--- a/test/clj_ravendb/client_caching_test.clj
+++ b/test/clj_ravendb/client_caching_test.clj
@@ -6,7 +6,7 @@
             [clj-ravendb.responses :as res]
             [clj-ravendb.config :refer :all]))
 
-(let [client (client ravendb-url ravendb-database {:caching? true})]
+(let [client (client ravendb-url ravendb-database {:caching? true :ssl-insecure? true})]
   (deftest test-load-documents-returns-correct-results
     (testing "documents loaded from cache have a :cached? flag"
       (let [doc-ids ["employees/1"]

--- a/test/clj_ravendb/client_debug_test.clj
+++ b/test/clj_ravendb/client_debug_test.clj
@@ -6,14 +6,14 @@
             [clj-ravendb.config :refer :all]))
 
 (let [expected [:Remark]]
-  (let [client (client ravendb-url ravendb-database)]
+  (let [client (client ravendb-url ravendb-database {:ssl-insecure? true})]
     (deftest test-user-info-returns-correct-result
       (testing "user-info returns the correct results"
         (let [actual (:info (user-info client))]
           (doseq [k expected]
             (is (not (nil? (k actual)))))))))
 
-  (let [client (client ravendb-url ravendb-database {:caching? true})]
+  (let [client (client ravendb-url ravendb-database {:caching? true :ssl-insecure? true})]
     (deftest test-user-info-returns-correct-result-when-using-cache-client
       (testing "user-info returns the correct results when using a cache client"
         (let [actual (:info (user-info client))]

--- a/test/clj_ravendb/client_debug_test.clj
+++ b/test/clj_ravendb/client_debug_test.clj
@@ -6,14 +6,14 @@
             [clj-ravendb.config :refer :all]))
 
 (let [expected [:Remark]]
-  (let [client (client ravendb-url ravendb-database {:ssl-insecure? true})]
+  (let [client (client ravendb-url ravendb-database {:ssl-insecure? true :oauth-url oauth-url :api-key api-key})]
     (deftest test-user-info-returns-correct-result
       (testing "user-info returns the correct results"
         (let [actual (:info (user-info client))]
           (doseq [k expected]
             (is (not (nil? (k actual)))))))))
 
-  (let [client (client ravendb-url ravendb-database {:caching? true :ssl-insecure? true})]
+  (let [client (client ravendb-url ravendb-database {:caching? true :ssl-insecure? true :oauth-url oauth-url :api-key api-key})]
     (deftest test-user-info-returns-correct-result-when-using-cache-client
       (testing "user-info returns the correct results when using a cache client"
         (let [actual (:info (user-info client))]

--- a/test/clj_ravendb/client_loading_documents_test.clj
+++ b/test/clj_ravendb/client_loading_documents_test.clj
@@ -5,7 +5,7 @@
             [clj-ravendb.responses :as res]
             [clj-ravendb.config :refer :all]))
 
-(let [client (client ravendb-url ravendb-database)]
+(let [client (client ravendb-url ravendb-database {:ssl-insecure? true})]
   (deftest test-load-documents-with-no-document-ids-throws
     (testing "Loading documents without specifying document ids
              throws an assertion error."

--- a/test/clj_ravendb/client_loading_documents_test.clj
+++ b/test/clj_ravendb/client_loading_documents_test.clj
@@ -5,7 +5,7 @@
             [clj-ravendb.responses :as res]
             [clj-ravendb.config :refer :all]))
 
-(let [client (client ravendb-url ravendb-database {:ssl-insecure? true})]
+(let [client (client ravendb-url ravendb-database {:ssl-insecure? true :oauth-url oauth-url :api-key api-key})]
   (deftest test-load-documents-with-no-document-ids-throws
     (testing "Loading documents without specifying document ids
              throws an assertion error."

--- a/test/clj_ravendb/client_putting_documents_test.clj
+++ b/test/clj_ravendb/client_putting_documents_test.clj
@@ -5,7 +5,7 @@
             [clj-ravendb.responses :as res]
             [clj-ravendb.config :refer :all]))
 
-(let [client (client ravendb-url ravendb-database)]
+(let [client (client ravendb-url ravendb-database {:ssl-insecure? true})]
   (deftest test-put-returns-correct-status-code
     (testing "processing a PUT command returns the correct result"
       (let [id "Key1"

--- a/test/clj_ravendb/client_putting_documents_test.clj
+++ b/test/clj_ravendb/client_putting_documents_test.clj
@@ -5,7 +5,7 @@
             [clj-ravendb.responses :as res]
             [clj-ravendb.config :refer :all]))
 
-(let [client (client ravendb-url ravendb-database {:ssl-insecure? true})]
+(let [client (client ravendb-url ravendb-database {:ssl-insecure? true :oauth-url oauth-url :api-key api-key})]
   (deftest test-put-returns-correct-status-code
     (testing "processing a PUT command returns the correct result"
       (let [id "Key1"

--- a/test/clj_ravendb/client_putting_indexes_test.clj
+++ b/test/clj_ravendb/client_putting_indexes_test.clj
@@ -5,7 +5,7 @@
             [clj-ravendb.responses :as res]
             [clj-ravendb.config :refer :all]))
 
-(let [client (client ravendb-url ravendb-database)
+(let [client (client ravendb-url ravendb-database {:ssl-insecure? true})
       idx {:name "DocumentsByName"
            :alias "doc"
            :where "doc.name ==\"Test\""

--- a/test/clj_ravendb/client_putting_indexes_test.clj
+++ b/test/clj_ravendb/client_putting_indexes_test.clj
@@ -5,7 +5,7 @@
             [clj-ravendb.responses :as res]
             [clj-ravendb.config :refer :all]))
 
-(let [client (client ravendb-url ravendb-database {:ssl-insecure? true})
+(let [client (client ravendb-url ravendb-database {:ssl-insecure? true :oauth-url oauth-url :api-key api-key})
       idx {:name "DocumentsByName"
            :alias "doc"
            :where "doc.name ==\"Test\""

--- a/test/clj_ravendb/client_querying_indexes_test.clj
+++ b/test/clj_ravendb/client_querying_indexes_test.clj
@@ -5,7 +5,7 @@
             [clj-ravendb.responses :as res]
             [clj-ravendb.config :refer :all]))
 
-(let [client (client ravendb-url ravendb-database {:ssl-insecure? true})
+(let [client (client ravendb-url ravendb-database {:ssl-insecure? true :oauth-url oauth-url :api-key api-key})
       qry {:index "Orders/ByCompany" :Count 10}]
   (deftest test-query-index-with-invalid-query
     (testing "Querying an index with an invalid query form."

--- a/test/clj_ravendb/client_querying_indexes_test.clj
+++ b/test/clj_ravendb/client_querying_indexes_test.clj
@@ -5,7 +5,7 @@
             [clj-ravendb.responses :as res]
             [clj-ravendb.config :refer :all]))
 
-(let [client (client ravendb-url ravendb-database)
+(let [client (client ravendb-url ravendb-database {:ssl-insecure? true})
       qry {:index "Orders/ByCompany" :Count 10}]
   (deftest test-query-index-with-invalid-query
     (testing "Querying an index with an invalid query form."

--- a/test/clj_ravendb/client_stats_test.clj
+++ b/test/clj_ravendb/client_stats_test.clj
@@ -7,14 +7,14 @@
 
 (let [expected [:LastDocEtag :LastAttachmentEtag :CountOfIndexes
                 :ApproximateTaskCount :CountOfDocuments :StaleIndexes]]
-  (let [client (client ravendb-url ravendb-database)]
+  (let [client (client ravendb-url ravendb-database {:ssl-insecure? true})]
     (deftest test-stats-returns-correct-result
       (testing "stats returns the correct results"
         (let [actual (:results (stats client))]
           (doseq [k expected]
             (is (not (nil? (k actual)))))))))
 
-  (let [client (client ravendb-url ravendb-database {:caching? true})]
+  (let [client (client ravendb-url ravendb-database {:caching? true :ssl-insecure? true})]
     (deftest test-stats-returns-correct-result-when-using-cache-client
       (testing "stats returns the correct results when using a cache client"
         (let [actual (:results (stats client))]

--- a/test/clj_ravendb/client_stats_test.clj
+++ b/test/clj_ravendb/client_stats_test.clj
@@ -7,14 +7,14 @@
 
 (let [expected [:LastDocEtag :LastAttachmentEtag :CountOfIndexes
                 :ApproximateTaskCount :CountOfDocuments :StaleIndexes]]
-  (let [client (client ravendb-url ravendb-database {:ssl-insecure? true})]
+  (let [client (client ravendb-url ravendb-database {:ssl-insecure? true :oauth-url oauth-url :api-key api-key})]
     (deftest test-stats-returns-correct-result
       (testing "stats returns the correct results"
         (let [actual (:results (stats client))]
           (doseq [k expected]
             (is (not (nil? (k actual)))))))))
 
-  (let [client (client ravendb-url ravendb-database {:caching? true :ssl-insecure? true})]
+  (let [client (client ravendb-url ravendb-database {:caching? true :ssl-insecure? true :oauth-url oauth-url :api-key api-key})]
     (deftest test-stats-returns-correct-result-when-using-cache-client
       (testing "stats returns the correct results when using a cache client"
         (let [actual (:results (stats client))]

--- a/test/clj_ravendb/client_watching_test.clj
+++ b/test/clj_ravendb/client_watching_test.clj
@@ -6,7 +6,7 @@
             [clj-ravendb.config :refer :all]
             [clojure.core.async :refer [go chan thread <!! >!! <! >!]]))
 
-(let [client (client ravendb-url ravendb-database)]
+(let [client (client ravendb-url ravendb-database {:ssl-insecure? true})]
   (deftest test-watching-document-puts-to-channel-on-document-change
     (testing "Watching a document puts to a channel on document change"
       (let [id "TestDocToWatch"

--- a/test/clj_ravendb/client_watching_test.clj
+++ b/test/clj_ravendb/client_watching_test.clj
@@ -6,7 +6,7 @@
             [clj-ravendb.config :refer :all]
             [clojure.core.async :refer [go chan thread <!! >!! <! >!]]))
 
-(let [client (client ravendb-url ravendb-database {:ssl-insecure? true})]
+(let [client (client ravendb-url ravendb-database {:ssl-insecure? true :oauth-url oauth-url :api-key api-key})]
   (deftest test-watching-document-puts-to-channel-on-document-change
     (testing "Watching a document puts to a channel on document change"
       (let [id "TestDocToWatch"

--- a/test/clj_ravendb/config.clj
+++ b/test/clj_ravendb/config.clj
@@ -2,3 +2,6 @@
 
 (def ravendb-url "https://markwoodhall-qlke.ravenhq.com")
 (def ravendb-database "markwoodhall-northwind")
+
+(def oauth-url "https://amazon-useast-2-oauth.ravenhq.com")
+(def api-key "a670daab-d226-49ea-8afb-a065faedd628")

--- a/test/clj_ravendb/config.clj
+++ b/test/clj_ravendb/config.clj
@@ -1,4 +1,4 @@
 (ns clj-ravendb.config)
 
-(def ravendb-url "http://192.168.0.40:8080")
-(def ravendb-database "northwind")
+(def ravendb-url "https://markwoodhall-qlke.ravenhq.com")
+(def ravendb-database "markwoodhall-northwind")


### PR DESCRIPTION
Add oauth support.
Change tests to use raven database hosted at ravenhq.com and to use an auth enabled client.
Since the test database is "in the cloud" we can run tests on push to master, so I've added .travis.yml
